### PR TITLE
Changed chat logic from string to attributed string

### DIFF
--- a/JSQMessages.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JSQMessages.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -177,7 +177,7 @@
     if (!copyMessage) {
         copyMessage = [JSQMessage messageWithSenderId:kJSQDemoAvatarIdJobs
                                           displayName:kJSQDemoAvatarDisplayNameJobs
-                                                 text:@"First received!"];
+                                       attributedText:[[NSAttributedString alloc] initWithString:@"First received!"]];
     }
     
     /**
@@ -263,7 +263,7 @@
              */
             newMessage = [JSQMessage messageWithSenderId:randomUserId
                                              displayName:self.demoData.users[randomUserId]
-                                                    text:copyMessage.text];
+                                          attributedText:copyMessage.attributedText];
         }
         
         /**
@@ -350,7 +350,7 @@
     JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId
                                              senderDisplayName:senderDisplayName
                                                           date:date
-                                                          text:text];
+                                                          attributedText:[[NSAttributedString alloc] initWithString:text]];
     
     [self.demoData.messages addObject:message];
     

--- a/JSQMessagesDemo/DemoModelData.m
+++ b/JSQMessagesDemo/DemoModelData.m
@@ -100,32 +100,32 @@
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdSquires
                                         senderDisplayName:kJSQDemoAvatarDisplayNameSquires
                                                      date:[NSDate distantPast]
-                                                     text:NSLocalizedString(@"Welcome to JSQMessages: A messaging UI framework for iOS.", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"Welcome to JSQMessages: A messaging UI framework for iOS.", nil)]],
                      
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdWoz
                                         senderDisplayName:kJSQDemoAvatarDisplayNameWoz
                                                      date:[NSDate distantPast]
-                                                     text:NSLocalizedString(@"It is simple, elegant, and easy to use. There are super sweet default settings, but you can customize like crazy.", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"It is simple, elegant, and easy to use. There are super sweet default settings, but you can customize like crazy.", nil)]],
                      
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdSquires
                                         senderDisplayName:kJSQDemoAvatarDisplayNameSquires
                                                      date:[NSDate distantPast]
-                                                     text:NSLocalizedString(@"It even has data detectors. You can call me tonight. My cell number is 123-456-7890. My website is www.hexedbits.com.", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"It even has data detectors. You can call me tonight. My cell number is 123-456-7890. My website is www.hexedbits.com.", nil)]],
                      
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdJobs
                                         senderDisplayName:kJSQDemoAvatarDisplayNameJobs
                                                      date:[NSDate date]
-                                                     text:NSLocalizedString(@"JSQMessagesViewController is nearly an exact replica of the iOS Messages App. And perhaps, better.", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"JSQMessagesViewController is nearly an exact replica of the iOS Messages App. And perhaps, better.", nil)]],
                      
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdCook
                                         senderDisplayName:kJSQDemoAvatarDisplayNameCook
                                                      date:[NSDate date]
-                                                     text:NSLocalizedString(@"It is unit-tested, free, open-source, and documented.", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"It is unit-tested, free, open-source, and documented.", nil)]],
                      
                      [[JSQMessage alloc] initWithSenderId:kJSQDemoAvatarIdSquires
                                         senderDisplayName:kJSQDemoAvatarDisplayNameSquires
                                                      date:[NSDate date]
-                                                     text:NSLocalizedString(@"Now with media messages!", nil)],
+                                           attributedText:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"Now with media messages!", nil)]],
                      nil];
     
     [self addPhotoMediaMessage];
@@ -149,7 +149,7 @@
     if ([NSUserDefaults longMessageSetting]) {
         JSQMessage *reallyLongMessage = [JSQMessage messageWithSenderId:kJSQDemoAvatarIdSquires
                                                             displayName:kJSQDemoAvatarDisplayNameSquires
-                                                                   text:@"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? END Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? END"];
+                                                                   attributedText:[[NSAttributedString alloc] initWithString:@"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? END Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? END"]];
         
         [self.messages addObject:reallyLongMessage];
     }

--- a/JSQMessagesTests/ModelTests/JSQMessageTextTests.m
+++ b/JSQMessagesTests/ModelTests/JSQMessageTextTests.m
@@ -18,7 +18,7 @@
 @property (strong, nonatomic) NSString *senderId;
 @property (strong, nonatomic) NSString *senderDisplayName;
 @property (strong, nonatomic) NSDate *date;
-@property (strong, nonatomic) NSString *text;
+@property (strong, nonatomic) NSAttributedString *attributedText;
 
 @end
 
@@ -33,9 +33,9 @@
     self.senderDisplayName = @"Jesse Squires";
     self.date = [NSDate date];
     
-    self.text = @"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque"
-    @"laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi"
-    @"architecto beatae vitae dicta sunt explicabo.";
+    self.attributedText = [[NSAttributedString alloc] initWithString:@"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque"
+                           @"laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi"
+                           @"architecto beatae vitae dicta sunt explicabo."];
 }
 
 - (void)tearDown
@@ -43,7 +43,7 @@
     self.senderId = nil;
     self.senderDisplayName = nil;
     self.date = nil;
-    self.text = nil;
+    self.attributedText = nil;
     [super tearDown];
 }
 
@@ -54,7 +54,7 @@
     JSQMessage *msg = [[JSQMessage alloc] initWithSenderId:self.senderId
                                          senderDisplayName:self.senderDisplayName
                                                       date:self.date
-                                                      text:self.text];
+                                            attributedText:self.attributedText];
     XCTAssertNotNil(msg, @"Message should not be nil");
 }
 
@@ -63,7 +63,7 @@
     JSQMessage *msg = [[JSQMessage alloc] initWithSenderId:self.senderId
                                          senderDisplayName:self.senderDisplayName
                                                       date:self.date
-                                                      text:self.text];
+                                            attributedText:self.attributedText];
     JSQMessage *copy = [msg copy];
     
     XCTAssertEqualObjects(msg, copy, @"Copied messages should be equal");
@@ -78,7 +78,7 @@
     JSQMessage *msg = [[JSQMessage alloc] initWithSenderId:self.senderId
                                          senderDisplayName:self.senderDisplayName
                                                       date:self.date
-                                                      text:self.text];
+                                            attributedText:self.attributedText];
     NSData *msgData = [NSKeyedArchiver archivedDataWithRootObject:msg];
     
     JSQMessage *unarchivedMsg = [NSKeyedUnarchiver unarchiveObjectWithData:msgData];

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -519,7 +519,7 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     cell.delegate = collectionView;
 
     if (!isMediaMessage) {
-        cell.textView.text = [messageItem text];
+        cell.textView.attributedText = [messageItem attributedText];
         NSParameterAssert(cell.textView.text != nil);
 
         id<JSQMessageBubbleImageDataSource> bubbleImageDataSource = [collectionView.dataSource collectionView:collectionView messageBubbleImageDataForItemAtIndexPath:indexPath];
@@ -590,7 +590,7 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     if (!isMediaMessage) {
         cell.accessibilityLabel = [NSString stringWithFormat:[NSBundle jsq_localizedStringForKey:@"text_message_accessibility_label"],
                                    [messageItem senderDisplayName],
-                                   [messageItem text]];
+                                   [messageItem attributedText].string];
     }
     else {
         cell.accessibilityLabel = [NSString stringWithFormat:[NSBundle jsq_localizedStringForKey:@"media_message_accessibility_label"],
@@ -687,7 +687,7 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
                                          forPasteboardType:[mediaData mediaDataType]];
             }
         } else {
-            [[UIPasteboard generalPasteboard] setString:[messageData text]];
+            [[UIPasteboard generalPasteboard] setString:[messageData attributedText].string];
         }
     }
     else if (action == @selector(delete:)) {

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -115,11 +115,10 @@
 
         CGFloat horizontalInsetsTotal = horizontalContainerInsets + horizontalFrameInsets + spacingBetweenAvatarAndBubble;
         CGFloat maximumTextWidth = [self textBubbleWidthForLayout:layout] - avatarSize.width - layout.messageBubbleLeftRightMargin - horizontalInsetsTotal;
-
-        CGRect stringRect = [[messageData text] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
-                                                             options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
-                                                          attributes:@{ NSFontAttributeName : layout.messageBubbleFont }
-                                                             context:nil];
+        
+        CGRect stringRect = [[messageData attributedText] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
+                                                              options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
+                                                              context:nil];
 
         CGSize stringSize = CGRectIntegral(stringRect).size;
 

--- a/JSQMessagesViewController/Model/JSQMessage.h
+++ b/JSQMessagesViewController/Model/JSQMessage.h
@@ -57,7 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  Returns the body text of the message, or `nil` if the message is a media message.
  *  That is, if `isMediaMessage` is equal to `YES` then this value will be `nil`.
  */
-@property (copy, nonatomic, readonly, null_unspecified) NSString *text;
+    
+@property (copy, nonatomic, readonly, null_unspecified) NSAttributedString *attributedText;
 
 /**
  *  Returns the media item attachment of the message, or `nil` if the message is not a media message.
@@ -72,9 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  Initializes and returns a message object having the given senderId, displayName, text,
  *  and current system date.
  *
- *  @param senderId    The unique identifier for the user who sent the message. This value must not be `nil`.
- *  @param displayName The display name for the user who sent the message. This value must not be `nil`.
- *  @param text        The body text of the message. This value must not be `nil`.
+ *  @param senderId       The unique identifier for the user who sent the message. This value must not be `nil`.
+ *  @param displayName    The display name for the user who sent the message. This value must not be `nil`.
+ *  @param attributedText The body text of the message. This value must not be `nil`.
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *
@@ -82,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)messageWithSenderId:(NSString *)senderId
                         displayName:(NSString *)displayName
-                               text:(NSString *)text;
+                     attributedText:(NSAttributedString *)attributedText;
 
 /**
  *  Initializes and returns a message object having the given senderId, senderDisplayName, date, and text.
@@ -90,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param senderId          The unique identifier for the user who sent the message. This value must not be `nil`.
  *  @param senderDisplayName The display name for the user who sent the message. This value must not be `nil`.
  *  @param date              The date that the message was sent. This value must not be `nil`.
- *  @param text              The body text of the message. This value must not be `nil`.
+ *  @param attributedText    The body text of the message. This value must not be `nil`.
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *
@@ -99,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSenderId:(NSString *)senderId
                senderDisplayName:(NSString *)senderDisplayName
                             date:(NSDate *)date
-                            text:(NSString *)text;
+                  attributedText:(NSAttributedString *)attributedText;
 /**
  *  Initializes and returns a message object having the given senderId, displayName, media,
  *  and current system date.

--- a/JSQMessagesViewController/Model/JSQMessage.m
+++ b/JSQMessagesViewController/Model/JSQMessage.m
@@ -25,24 +25,24 @@
 
 + (instancetype)messageWithSenderId:(NSString *)senderId
                         displayName:(NSString *)displayName
-                               text:(NSString *)text
+                     attributedText:(NSAttributedString *)attributedText
 {
     return [[self alloc] initWithSenderId:senderId
                         senderDisplayName:displayName
                                      date:[NSDate date]
-                                     text:text];
+                           attributedText:attributedText];
 }
 
 - (instancetype)initWithSenderId:(NSString *)senderId
                senderDisplayName:(NSString *)senderDisplayName
                             date:(NSDate *)date
-                            text:(NSString *)text
+                  attributedText:(NSAttributedString *)attributedText
 {
-    NSParameterAssert(text != nil);
+    NSParameterAssert(attributedText != nil);
 
     self = [self initWithSenderId:senderId senderDisplayName:senderDisplayName date:date isMedia:NO];
     if (self) {
-        _text = [text copy];
+        _attributedText = [attributedText copy];
     }
     return self;
 }
@@ -113,7 +113,7 @@
         return NO;
     }
 
-    BOOL hasEqualContent = self.isMediaMessage ? [self.media isEqual:aMessage.media] : [self.text isEqualToString:aMessage.text];
+    BOOL hasEqualContent = self.isMediaMessage ? [self.media isEqual:aMessage.media] : [self.attributedText isEqualToAttributedString:aMessage.attributedText];
 
     return [self.senderId isEqualToString:aMessage.senderId]
     && [self.senderDisplayName isEqualToString:aMessage.senderDisplayName]
@@ -123,14 +123,14 @@
 
 - (NSUInteger)hash
 {
-    NSUInteger contentHash = self.isMediaMessage ? [self.media mediaHash] : self.text.hash;
+    NSUInteger contentHash = self.isMediaMessage ? [self.media mediaHash] : self.attributedText.string.hash;
     return self.senderId.hash ^ self.date.hash ^ contentHash;
 }
 
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@: senderId=%@, senderDisplayName=%@, date=%@, isMediaMessage=%@, text=%@, media=%@>",
-            [self class], self.senderId, self.senderDisplayName, self.date, @(self.isMediaMessage), self.text, self.media];
+            [self class], self.senderId, self.senderDisplayName, self.date, @(self.isMediaMessage), self.attributedText, self.media];
 }
 
 - (id)debugQuickLookObject
@@ -148,7 +148,7 @@
         _senderDisplayName = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(senderDisplayName))];
         _date = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(date))];
         _isMediaMessage = [aDecoder decodeBoolForKey:NSStringFromSelector(@selector(isMediaMessage))];
-        _text = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(text))];
+        _attributedText = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(attributedText))];
         _media = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(media))];
     }
     return self;
@@ -160,7 +160,7 @@
     [aCoder encodeObject:self.senderDisplayName forKey:NSStringFromSelector(@selector(senderDisplayName))];
     [aCoder encodeObject:self.date forKey:NSStringFromSelector(@selector(date))];
     [aCoder encodeBool:self.isMediaMessage forKey:NSStringFromSelector(@selector(isMediaMessage))];
-    [aCoder encodeObject:self.text forKey:NSStringFromSelector(@selector(text))];
+    [aCoder encodeObject:self.attributedText forKey:NSStringFromSelector(@selector(attributedText))];
 
     if ([self.media conformsToProtocol:@protocol(NSCoding)]) {
         [aCoder encodeObject:self.media forKey:NSStringFromSelector(@selector(media))];
@@ -181,7 +181,7 @@
     return [[[self class] allocWithZone:zone] initWithSenderId:self.senderId
                                              senderDisplayName:self.senderDisplayName
                                                           date:self.date
-                                                          text:self.text];
+                                                attributedText:self.attributedText];
 }
 
 @end

--- a/JSQMessagesViewController/Model/JSQMessageData.h
+++ b/JSQMessagesViewController/Model/JSQMessageData.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @warning You must not return `nil` from this method.
  */
-- (NSString *)text;
+- (NSAttributedString *)attributedText;
 
 /**
  *  @return The media item of the message.


### PR DESCRIPTION
Полностью убрал из чата использование обычной строки, добавил NSAttributedString
Теперь чат умеет отображать html и прочее.
Важно, что надо либо самим всегда задавать шрифт для текста, либо чтобы бэк присылал его, если речь идет про html. Но лучше, наверное, первый вариант.

В коде есть всякие вложенные создания строк и так далее. Не хочу их убирать, в сдк в принципе такие места есть и в стиль кода это вполне вписывается, хоть мне и не нравится.
Убирать это прямо очень не хочу, но если кто-то категорически против, то пишите тогда.