### PR TITLE
MOB-6412: Chat redesign

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -114,7 +114,7 @@
         CGFloat horizontalFrameInsets = layout.messageBubbleTextViewFrameInsets.left + layout.messageBubbleTextViewFrameInsets.right;
 
         CGFloat horizontalInsetsTotal = horizontalContainerInsets + horizontalFrameInsets + spacingBetweenAvatarAndBubble;
-        CGFloat maximumTextWidth = [self textBubbleWidthForLayout:layout] - avatarSize.width - layout.messageBubbleLeftRightMargin - horizontalInsetsTotal;
+        CGFloat maximumTextWidth = [self textBubbleWidthForLayout:layout] - avatarSize.width - [layout messageBubbleLeftRightMarginAtIndexPath:indexPath] - horizontalInsetsTotal;
         
         CGRect stringRect = [[messageData attributedText] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
                                                               options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
@@ -216,6 +216,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param indexPath The index path of the item to be displayed.
  *
  *  @return The margin of the item displayed at indexPath.
+ *
+ *  @see messageBubbleLeftRightMargin
  */
 - (CGFloat)messageBubbleLeftRightMarginAtIndexPath:(NSIndexPath *)indexPath;
 

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
@@ -210,6 +210,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (CGSize)sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ *  Computes and returns the left & right margin of the item specified by indexPath.
+ *
+ *  @param indexPath The index path of the item to be displayed.
+ *
+ *  @return The margin of the item displayed at indexPath.
+ */
+- (CGFloat)messageBubbleLeftRightMarginAtIndexPath:(NSIndexPath *)indexPath;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -425,6 +425,10 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
     return CGSizeMake(self.itemWidth, ceilf(finalHeight));
 }
 
+- (CGFloat)messageBubbleLeftRightMarginAtIndexPath:(NSIndexPath *)indexPath {
+    return self.messageBubbleLeftRightMargin;
+}
+
 - (void)jsq_configureMessageCellLayoutAttributes:(JSQMessagesCollectionViewLayoutAttributes *)layoutAttributes
 {
     NSIndexPath *indexPath = layoutAttributes.indexPath;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -224,13 +224,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)registerMenuAction:(SEL)action;
 
 /**
- *  Set avatar view size.
- *
- *  @param avatar size.
- */
-- (void)setAvatarViewSize:(CGSize)avatarViewSize;
-
-/**
  *  Set width constraint to screen size.
  */
 - (void)setFullScreenWidthConstraint;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -223,6 +223,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)registerMenuAction:(SEL)action;
 
+/**
+ *  Set avatar view size.
+ *
+ *  @param avatar size.
+ */
+- (void)setAvatarViewSize:(CGSize)avatarViewSize;
+
+/**
+ *  Set width constraint to screen size.
+ */
+- (void)setFullScreenWidthConstraint;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -223,11 +223,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)registerMenuAction:(SEL)action;
 
-/**
- *  Set width constraint to screen size.
- */
-- (void)setFullScreenWidthConstraint;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -60,8 +60,6 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
 @property (weak, nonatomic) IBOutlet UIImageView *messageStatusImageView;
 
-@property (strong, nonatomic) IBOutlet NSLayoutConstraint *bubbleContainerLeadingConstraint;
-
 @property (assign, nonatomic) UIEdgeInsets textViewFrameInsets;
 
 @property (assign, nonatomic) CGSize avatarViewSize;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -60,6 +60,8 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
 @property (weak, nonatomic) IBOutlet UIImageView *messageStatusImageView;
 
+@property (strong, nonatomic) IBOutlet NSLayoutConstraint *bubbleContainerLeadingConstraint;
+
 @property (assign, nonatomic) UIEdgeInsets textViewFrameInsets;
 
 @property (assign, nonatomic) CGSize avatarViewSize;
@@ -243,6 +245,10 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     [super setSelected:selected];
     self.avatarImageView.highlighted = selected;
     self.messageBubbleImageView.highlighted = selected;
+}
+
+- (void)setFullScreenWidthConstraint {
+    self.messageBubbleContainerWidthConstraint.constant = [[UIScreen mainScreen] bounds].size.width - self.bubbleContainerLeadingConstraint.constant * 2;
 }
 
 

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -247,11 +247,6 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     self.messageBubbleImageView.highlighted = selected;
 }
 
-- (void)setFullScreenWidthConstraint {
-    self.messageBubbleContainerWidthConstraint.constant = [[UIScreen mainScreen] bounds].size.width - self.bubbleContainerLeadingConstraint.constant * 2;
-}
-
-
 #pragma mark - Menu actions
 
 - (BOOL)respondsToSelector:(SEL)aSelector

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
@@ -106,7 +106,7 @@
             <constraints>
                 <constraint firstItem="Da1-09-wR4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="afj-rd-iNv" secondAttribute="bottom" id="090-VM-DaV"/>
                 <constraint firstItem="Ufa-bF-l1Y" firstAttribute="leading" secondItem="btS-p8-B7Z" secondAttribute="leading" id="398-R4-PZO"/>
-                <constraint firstItem="UPz-5x-c1T" firstAttribute="leading" secondItem="4lh-CK-yVn" secondAttribute="leading" id="54r-MX-MGW"/>
+                <constraint firstItem="UPz-5x-c1T" firstAttribute="leading" secondItem="btS-p8-B7Z" secondAttribute="leading" id="54r-MX-MGW"/>
                 <constraint firstAttribute="trailing" secondItem="UPz-5x-c1T" secondAttribute="trailing" id="G3U-h0-DWS"/>
                 <constraint firstAttribute="trailing" secondItem="afj-rd-iNv" secondAttribute="trailing" id="Ka4-Dy-jCS"/>
                 <constraint firstItem="Md1-I7-2AZ" firstAttribute="centerY" secondItem="btS-p8-B7Z" secondAttribute="centerY" id="LQ0-vF-qkk"/>

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,7 +29,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="bubble top label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ufa-bF-l1Y" userLabel="Bubble top label" customClass="JSQMessagesLabel">
-                        <rect key="frame" x="40" y="20" width="280" height="20"/>
+                        <rect key="frame" x="36" y="20" width="284" height="20"/>
                         <color key="backgroundColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="fal-sy-hrK"/>
@@ -105,6 +105,7 @@
             </view>
             <constraints>
                 <constraint firstItem="Da1-09-wR4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="afj-rd-iNv" secondAttribute="bottom" id="090-VM-DaV"/>
+                <constraint firstItem="Ufa-bF-l1Y" firstAttribute="leading" secondItem="btS-p8-B7Z" secondAttribute="leading" id="398-R4-PZO"/>
                 <constraint firstItem="UPz-5x-c1T" firstAttribute="leading" secondItem="4lh-CK-yVn" secondAttribute="leading" id="54r-MX-MGW"/>
                 <constraint firstAttribute="trailing" secondItem="UPz-5x-c1T" secondAttribute="trailing" id="G3U-h0-DWS"/>
                 <constraint firstAttribute="trailing" secondItem="afj-rd-iNv" secondAttribute="trailing" id="Ka4-Dy-jCS"/>
@@ -119,7 +120,6 @@
                 <constraint firstItem="btS-p8-B7Z" firstAttribute="top" secondItem="Ufa-bF-l1Y" secondAttribute="bottom" id="jAu-Dn-7rN"/>
                 <constraint firstItem="Da1-09-wR4" firstAttribute="leading" secondItem="4lh-CK-yVn" secondAttribute="leading" id="jiu-B4-TSD"/>
                 <constraint firstAttribute="bottom" secondItem="UPz-5x-c1T" secondAttribute="bottom" id="nsK-Gh-M3Z"/>
-                <constraint firstItem="Ufa-bF-l1Y" firstAttribute="leading" secondItem="4lh-CK-yVn" secondAttribute="leading" constant="40" id="rMh-SW-ODN"/>
                 <constraint firstItem="UPz-5x-c1T" firstAttribute="top" secondItem="btS-p8-B7Z" secondAttribute="bottom" id="s8G-Je-7GA"/>
             </constraints>
             <size key="customSize" width="317" height="245"/>
@@ -129,6 +129,7 @@
                 <outlet property="avatarContainerViewHeightConstraint" destination="tZk-AK-JFa" id="tPu-mC-ITh"/>
                 <outlet property="avatarContainerViewWidthConstraint" destination="YwX-fW-Me6" id="5PN-NL-hEP"/>
                 <outlet property="avatarImageView" destination="w23-sL-0Rh" id="Yf4-UR-VRC"/>
+                <outlet property="bubbleContainerLeadingConstraint" destination="j0I-pm-eex" id="MWO-P3-Gad"/>
                 <outlet property="cellBottomLabel" destination="UPz-5x-c1T" id="MKm-hp-T6v"/>
                 <outlet property="cellBottomLabelHeightConstraint" destination="xPR-Ph-Ze9" id="nvV-Tk-AIs"/>
                 <outlet property="cellTopLabel" destination="afj-rd-iNv" id="bTd-4q-U7e"/>
@@ -144,7 +145,7 @@
                 <outlet property="textViewMarginHorizontalSpaceConstraint" destination="4qS-03-PFO" id="1Qe-Ee-fUO"/>
                 <outlet property="textViewTopVerticalSpaceConstraint" destination="aEL-yH-N1p" id="WPl-0b-tf1"/>
             </connections>
-            <point key="canvasLocation" x="255" y="202"/>
+            <point key="canvasLocation" x="369.56521739130437" y="135.26785714285714"/>
         </collectionViewCell>
     </objects>
 </document>

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCellIncoming.xib
@@ -129,7 +129,6 @@
                 <outlet property="avatarContainerViewHeightConstraint" destination="tZk-AK-JFa" id="tPu-mC-ITh"/>
                 <outlet property="avatarContainerViewWidthConstraint" destination="YwX-fW-Me6" id="5PN-NL-hEP"/>
                 <outlet property="avatarImageView" destination="w23-sL-0Rh" id="Yf4-UR-VRC"/>
-                <outlet property="bubbleContainerLeadingConstraint" destination="j0I-pm-eex" id="MWO-P3-Gad"/>
                 <outlet property="cellBottomLabel" destination="UPz-5x-c1T" id="MKm-hp-T6v"/>
                 <outlet property="cellBottomLabelHeightConstraint" destination="xPR-Ph-Ze9" id="nvV-Tk-AIs"/>
                 <outlet property="cellTopLabel" destination="afj-rd-iNv" id="bTd-4q-U7e"/>


### PR DESCRIPTION
Добавлены методы для настройки ширины аватарки и ширины сообщения
(нужны для того, чтобы убрать аватарку и растянуть сообщение от робота в чате с препом на весь экран)